### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ fastapi
 uvicorn
 pillow
 black
+pytest
+httpx
+python-multipart

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,41 @@
+from fastapi.testclient import TestClient
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app import app
+
+
+def test_index_returns_html():
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "text/html" in response.headers.get("content-type", "")
+
+
+def test_print_endpoint(monkeypatch):
+    client = TestClient(app)
+    called = []
+
+    def fake_spool_raw(printer_name, payload):
+        called.append((printer_name, payload))
+
+    monkeypatch.setattr("app.spool_raw", fake_spool_raw)
+
+    from PIL import Image
+    import io
+
+    img = Image.new("RGB", (463, 10), color="black")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    buf.seek(0)
+
+    files = {"file": ("test.png", buf.getvalue(), "image/png")}
+    data = {"media": "continuous58", "lang": "EPL"}
+    response = client.post("/print", files=files, data=data)
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    assert called, "spool_raw was not called"
+    printer_name, payload = called[0]
+    assert printer_name == "zebra2844"
+    assert isinstance(payload, (bytes, bytearray))

--- a/tests/test_imaging.py
+++ b/tests/test_imaging.py
@@ -1,0 +1,15 @@
+from imaging.process import to_1bit
+from PIL import Image
+import io
+
+
+def test_to_1bit_converts_and_resizes():
+    img = Image.new("RGB", (10, 5), "black")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    result = to_1bit(buf.getvalue(), 20)
+    assert result.mode == "1"
+    assert result.size == (20, 10)
+    pixels = result.load()
+    assert pixels[0, 0] == 0
+    assert pixels[19, 9] == 0

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -1,0 +1,34 @@
+from PIL import Image
+import pytest
+from printer.epl import img_to_epl_gw
+from printer.zpl import img_to_zpl_gf
+
+
+def make_black_image():
+    return Image.new("1", (8, 8), 0)
+
+
+def test_img_to_epl_gw_formats_bytes():
+    img = make_black_image()
+    payload = img_to_epl_gw(img)
+    assert payload.startswith(b"N\nq8\nQ8,24\nGW20,20,1,8,")
+    assert payload.endswith(b"\nP1\n")
+    data = payload.split(b"GW20,20,1,8,")[1].split(b"\nP1\n")[0]
+    assert data == b"\xff" * 8
+
+
+def test_img_to_zpl_gf_formats_bytes():
+    img = make_black_image()
+    payload = img_to_zpl_gf(img)
+    assert payload.startswith(b"^XA^FO20,20^GFA,8,8,1,")
+    assert payload.endswith(b"^FS^XZ")
+    data = payload.split(b"^GFA,8,8,1,")[1].split(b"^FS^XZ")[0]
+    assert data == b"FFFFFFFFFFFFFFFF"
+
+
+def test_printer_functions_require_1bit():
+    img = Image.new("L", (8, 8), 0)
+    with pytest.raises(ValueError):
+        img_to_epl_gw(img)
+    with pytest.raises(ValueError):
+        img_to_zpl_gf(img)


### PR DESCRIPTION
## Summary
- add FastAPI endpoint tests
- run tests in GitHub Actions
- expand coverage for image processing and printer command generation

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b618bc43cc833289816249404f0335