### PR TITLE
docs: add badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Ditherbooth
 
+[![tests](https://github.com/AlexNly/ditherbooth/actions/workflows/tests.yml/badge.svg)](https://github.com/AlexNly/ditherbooth/actions/workflows/tests.yml)
+[![python](https://img.shields.io/badge/python-3.9%2B-blue.svg)](https://www.python.org/)
+[![code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 Ditherbooth is a small FastAPI service and single-page app for printing photos to a Zebra LP2844 label printer.  Images are uploaded through the web UI, converted to 1‑bit dithered bitmaps with Pillow, encoded as EPL2 or ZPL graphics commands, and spooled to CUPS as raw jobs.
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
- document test workflow, Python version, and Black code style badges in README

## Testing
- `python -m py_compile app.py imaging/process.py printer/cups.py printer/epl.py printer/zpl.py`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b61c5c638483329e1dd82b54672ad3