### PR TITLE
Add image processing exploration notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ curl -F "file=@path/to/image.jpg" \
 
 A JSON response of `{ "status": "ok" }` indicates the job was submitted.
 
+## Image processing notebook
+
+An example Jupyter notebook demonstrating the conversion of the sample image to a printable 1-bit bitmap is available at `notebooks/image_processing.ipynb`.
+
 ## Formatting and linting
 
 Format the code with:

--- a/notebooks/image_processing.ipynb
+++ b/notebooks/image_processing.ipynb
@@ -1,0 +1,103 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "d31cda4c",
+   "metadata": {},
+   "source": [
+    "# Explore Image Processing\n",
+    "This notebook demonstrates how the sample image is converted to a 1-bit format for printing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8aa815e3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from PIL import Image, ImageOps\n",
+    "from imaging.process import to_1bit"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15b73b41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image_path = Path('../20250902_0027_Party in the Park_simple_compose_01k43p7hzyfcst3ff4nfs6hatn.png')\n",
+    "original = Image.open(image_path)\n",
+    "original"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a8b9526",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert to grayscale\n",
+    "img_gray = ImageOps.exif_transpose(original).convert('L')\n",
+    "img_gray"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1bb0cf92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Resize to printer width\n",
+    "printer_width = 463\n",
+    "ratio = printer_width / img_gray.width\n",
+    "new_height = int(img_gray.height * ratio)\n",
+    "img_resized = img_gray.resize((printer_width, new_height), Image.LANCZOS)\n",
+    "img_resized"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70edaf08",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Convert to 1-bit\n",
+    "canvas = Image.new('L', (printer_width, new_height), 255)\n",
+    "canvas.paste(img_resized, (0,0))\n",
+    "final_img = canvas.convert('1')\n",
+    "final_img"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df407566",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the helper function directly\n",
+    "final_img_direct = to_1bit(image_path.read_bytes(), printer_width)\n",
+    "final_img_direct"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Add a Jupyter notebook demonstrating how the bundled sample image is converted to a 1-bit bitmap for printing
- Document the notebook's location in the README

## Testing
- `black .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b61f433a688332a69de03ef42bf7d7