### PR TITLE
Clean up spool_raw temp files

### DIFF
--- a/printer/cups.py
+++ b/printer/cups.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import tempfile
 from typing import Union
@@ -8,4 +9,7 @@ def spool_raw(printer_name: str, payload: Union[bytes, str]) -> None:
     with tempfile.NamedTemporaryFile(delete=False) as tmp:
         tmp.write(data)
         tmp_path = tmp.name
-    subprocess.run(["lpr", "-P", printer_name, "-o", "raw", tmp_path], check=True)
+    try:
+        subprocess.run(["lpr", "-P", printer_name, "-o", "raw", tmp_path], check=True)
+    finally:
+        os.unlink(tmp_path)


### PR DESCRIPTION
## Summary
- remove temp files after printing by using try/finally and os.unlink

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b6bdc23b288332911dba6984cdaa77