### PR TITLE
Use threadpool for printing

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from fastapi import FastAPI, File, Form, UploadFile
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
+from fastapi.concurrency import run_in_threadpool
 
 from imaging.process import to_1bit
 from printer.cups import spool_raw
@@ -53,5 +54,5 @@ async def print_image(
         payload = img_to_epl_gw(img)
     else:
         payload = img_to_zpl_gf(img)
-    spool_raw(PRINTER_NAME, payload)
+    await run_in_threadpool(spool_raw, PRINTER_NAME, payload)
     return {"status": "ok"}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -19,7 +19,10 @@ def test_print_endpoint(monkeypatch):
 
     def fake_spool_raw(printer_name, payload):
         called.append((printer_name, payload))
+    async def fake_run_in_threadpool(func, *args, **kwargs):
+        return func(*args, **kwargs)
 
+    monkeypatch.setattr("app.run_in_threadpool", fake_run_in_threadpool)
     monkeypatch.setattr("app.spool_raw", fake_spool_raw)
 
     from PIL import Image


### PR DESCRIPTION
## Summary
- Avoid blocking the event loop by running `spool_raw` in a threadpool
- Patch tests to stub out `run_in_threadpool`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b6bdcd4c5883329d64fe7956732213