### PR TITLE
Allow configuring printer via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Ditherbooth is a small FastAPI service and single-page app for printing photos t
 * Python 3.9+
 * [CUPS](https://www.cups.org/) with a **raw** queue named `zebra2844`
 * Zebra LP2844 or LP2844‑Z printer connected via USB
+* `DITHERBOOTH_PRINTER` environment variable (optional) to override the CUPS queue name; defaults to `zebra2844`
 
 ### Create a raw queue
 Plug the printer in and register it with CUPS.  Both Raspberry Pi OS and macOS ship with CUPS.

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from pathlib import Path
 import logging
+import os
 import subprocess
 
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
@@ -32,7 +33,7 @@ MEDIA_WIDTHS = {
     Media.label100x150: 799,
 }
 
-PRINTER_NAME = "zebra2844"
+PRINTER_NAME = os.getenv("DITHERBOOTH_PRINTER", "zebra2844")
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
 from fastapi.testclient import TestClient
 from pathlib import Path
 import sys
+import importlib
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from app import app
@@ -42,3 +43,10 @@ def test_print_endpoint(monkeypatch):
     printer_name, payload = called[0]
     assert printer_name == "zebra2844"
     assert isinstance(payload, (bytes, bytearray))
+
+
+def test_printer_name_from_env(monkeypatch):
+    monkeypatch.setenv("DITHERBOOTH_PRINTER", "myprinter")
+    import app as app_module
+    importlib.reload(app_module)
+    assert app_module.PRINTER_NAME == "myprinter"


### PR DESCRIPTION
## Summary
- read printer queue name from `DITHERBOOTH_PRINTER` with default `zebra2844`
- document `DITHERBOOTH_PRINTER` in README
- test environment variable overrides printer name

## Testing
- `pytest -q`
- `python -m py_compile app.py imaging/process.py printer/cups.py printer/epl.py printer/zpl.py`


------
https://chatgpt.com/codex/tasks/task_b_68b6e9c249b48332bcbea1eacbf7f1e2