### PR TITLE
Offload image conversion to threadpool

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,7 +57,9 @@ async def print_image(
     try:
         img_bytes = await file.read()
         width = MEDIA_WIDTHS[media]
-        img = to_1bit(img_bytes, width)
+        # Conversion to 1-bit is CPU-intensive, so run it in a thread pool to
+        # avoid blocking the event loop.
+        img = await run_in_threadpool(to_1bit, img_bytes, width)
         if lang == Lang.EPL:
             payload = img_to_epl_gw(img)
         else:


### PR DESCRIPTION
## Summary
- Avoid event-loop blocking by running `to_1bit` in a thread pool
- Document why image conversion is offloaded

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b7436467488332821da0986009bcb0