### PR TITLE
Separate runtime and development requirements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
       - name: Run tests with coverage
         run: pytest --cov=. --cov-report=xml
       - name: Upload coverage to Codecov

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ PY
 python3 -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
+# For development (tests, formatting, etc.):
+pip install -r requirements-dev.txt
 ```
 
 ### Run the development server
@@ -185,6 +187,8 @@ Optional intermediate views used for illustration (not sent to the printer):
 
 ## Formatting and linting
 
+Requires development dependencies.
+
 Format the code with:
 
 ```bash
@@ -193,9 +197,10 @@ make format
 
 ## Testing
 
-Run the test suite:
+Install development dependencies and run the test suite:
 
 ```bash
+pip install -r requirements-dev.txt
 pytest
 ```
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+
+black
+pytest
+pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,4 @@
 fastapi
 uvicorn
 pillow
-black
-pytest
-httpx
 python-multipart
-pytest-cov


### PR DESCRIPTION
## Summary
- limit runtime requirements to FastAPI, Uvicorn, Pillow, and upload helpers
- add `requirements-dev.txt` for formatting and test tools
- teach CI to install dev requirements and document both sets

## Testing
- `pip install -r requirements-dev.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68baffbebd788332a54ff98e545f6705