### PR TITLE
Default to Zebra LP2844 printer

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,20 +47,20 @@ Ditherbooth is a small FastAPI service and single-page app that turns uploaded p
 ### Prerequisites
 
 * Python 3.9+
-* [CUPS](https://www.cups.org/) with a **raw** queue named `zebra2844`
+* [CUPS](https://www.cups.org/) with a **raw** queue named `Zebra_LP2844`
 * Zebra LP2844 or LP2844‑Z printer connected via USB
-* `DITHERBOOTH_PRINTER` environment variable (optional) to override the CUPS queue name; defaults to `zebra2844`
+* `DITHERBOOTH_PRINTER` environment variable (optional) to override the CUPS queue name; defaults to `Zebra_LP2844`
 
 #### Create a raw queue
 
 ```bash
-sudo lpadmin -p zebra2844 -E -v usb://Zebra/LP2844 -m raw
+sudo lpadmin -p Zebra_LP2844 -E -v usb://Zebra/LP2844 -m raw
 ```
 
 Verify the queue:
 
 ```bash
-lpstat -p zebra2844
+lpstat -p Zebra_LP2844
 ```
 
 #### Smoke-test the printer
@@ -73,7 +73,7 @@ from ditherbooth.printer.cups import spool_raw
 payload = (
     'N\nq400\nQ200,24\nA50,50,0,3,1,1,N,"Hello"\nP1\n'
 )
-spool_raw('zebra2844', payload)
+spool_raw('Zebra_LP2844', payload)
 PY
 ```
 
@@ -126,7 +126,7 @@ Endpoints:
   * `default_media` (string: one of `continuous58`, `continuous80`, `label100x150`)
   * `default_lang` (string: `EPL` or `ZPL`)
   * `lock_controls` (bool) — hides media/language selectors in the UI for kiosk usage.
-  * `printer_name` (string, optional) — override the printer queue name used by the backend (otherwise falls back to `DITHERBOOTH_PRINTER` env, then `zebra2844`).
+  * `printer_name` (string, optional) — override the printer queue name used by the backend (otherwise falls back to `DITHERBOOTH_PRINTER` env, then `Zebra_LP2844`).
 
 ## API test with cURL
 

--- a/ditherbooth/app.py
+++ b/ditherbooth/app.py
@@ -38,7 +38,10 @@ MEDIA_WIDTHS = {
     Media.label100x150: 799,
 }
 
-PRINTER_NAME = os.getenv("DITHERBOOTH_PRINTER", "zebra2844")
+# Default to the typical CUPS queue name for Zebra LP2844 printers,
+# while still allowing overrides via the DITHERBOOTH_PRINTER environment
+# variable or the config file.
+PRINTER_NAME = os.getenv("DITHERBOOTH_PRINTER", "Zebra_LP2844")
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -131,7 +134,7 @@ DEFAULT_CONFIG = {
     "lock_controls": False,
     "test_mode_delay_ms": 0,
     # Optional: override printer queue name; falls back to PRINTER_NAME env.
-    # "printer_name": "zebra2844",
+    # "printer_name": "Zebra_LP2844",
 }
 
 

--- a/ditherbooth/static/index.html
+++ b/ditherbooth/static/index.html
@@ -108,7 +108,7 @@
                     </div>
                     <div class="field">
                         <label>Printer name (optional override)
-                            <input type="text" id="printerName" placeholder="e.g., zebra2844">
+                            <input type="text" id="printerName" placeholder="e.g., Zebra_LP2844">
                         </label>
                     </div>
                     <div class="actions end">

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -42,7 +42,7 @@ def test_print_endpoint(tmp_path, monkeypatch):
     assert response.json() == {"status": "ok"}
     assert called, "spool_raw was not called"
     printer_name, payload = called[0]
-    assert printer_name == "zebra2844"
+    assert printer_name == "Zebra_LP2844"
     assert isinstance(payload, (bytes, bytearray))
 
 


### PR DESCRIPTION
## Summary
- Default printing queue to `Zebra_LP2844` while retaining environment override
- Align tests, documentation and UI placeholders with new default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68bb3221e74c83328c0e7595a4d4bbd7