### PR TITLE
Invert printer bit logic for correct polarity

### DIFF
--- a/ditherbooth/printer/epl.py
+++ b/ditherbooth/printer/epl.py
@@ -13,7 +13,7 @@ def img_to_epl_gw(img: Image.Image, x: int = 20, y: int = 20) -> bytes:
         byte = 0
         bit_count = 0
         for col in range(width):
-            if pixels[col, row] == 0:
+            if pixels[col, row] == 255:
                 byte |= 1 << (7 - (bit_count % 8))
             bit_count += 1
             if bit_count % 8 == 0:

--- a/ditherbooth/printer/zpl.py
+++ b/ditherbooth/printer/zpl.py
@@ -13,7 +13,7 @@ def img_to_zpl_gf(img: Image.Image, x: int = 20, y: int = 20) -> bytes:
         byte = 0
         bit_count = 0
         for col in range(width):
-            if pixels[col, row] == 0:
+            if pixels[col, row] == 255:
                 byte |= 1 << (7 - (bit_count % 8))
             bit_count += 1
             if bit_count % 8 == 0:

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -14,7 +14,7 @@ def test_img_to_epl_gw_formats_bytes():
     assert payload.startswith(b"N\nq8\nQ8,24\nGW20,20,1,8,")
     assert payload.endswith(b"\nP1\n")
     data = payload.split(b"GW20,20,1,8,")[1].split(b"\nP1\n")[0]
-    assert data == b"\xff" * 8
+    assert data == b"\x00" * 8
 
 
 def test_img_to_zpl_gf_formats_bytes():
@@ -23,7 +23,7 @@ def test_img_to_zpl_gf_formats_bytes():
     assert payload.startswith(b"^XA^FO20,20^GFA,8,8,1,")
     assert payload.endswith(b"^FS^XZ")
     data = payload.split(b"^GFA,8,8,1,")[1].split(b"^FS^XZ")[0]
-    assert data == b"FFFFFFFFFFFFFFFF"
+    assert data == b"0000000000000000"
 
 
 def test_printer_functions_require_1bit():


### PR DESCRIPTION
## Summary
- treat pixel value 255 as black when building EPL and ZPL payloads
- adjust printer unit tests for new bit polarity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bb343c15b88332b1108f89f039f1fb