### PR TITLE
Pad label media and use fixed EPL height

### DIFF
--- a/ditherbooth/printer/epl.py
+++ b/ditherbooth/printer/epl.py
@@ -1,8 +1,15 @@
 import math
+from typing import Optional
 from PIL import Image
 
 
-def img_to_epl_gw(img: Image.Image, x: int = 20, y: int = 20, gap: int = 24) -> bytes:
+def img_to_epl_gw(
+    img: Image.Image,
+    x: int = 20,
+    y: int = 20,
+    gap: int = 24,
+    label_height: Optional[int] = None,
+) -> bytes:
     if img.mode != "1":
         raise ValueError("Image must be 1-bit")
     width, height = img.size
@@ -21,6 +28,7 @@ def img_to_epl_gw(img: Image.Image, x: int = 20, y: int = 20, gap: int = 24) -> 
                 byte = 0
         if bit_count % 8 != 0:
             data.append(byte)
-    header = f"N\nq{width}\nQ{height},{gap}\n".encode()
+    target_height = label_height or height
+    header = f"N\nq{width}\nQ{target_height},{gap}\n".encode()
     command = f"GW{x},{y},{row_bytes},{height},".encode()
     return header + command + bytes(data) + b"\nP1\n"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -79,7 +79,7 @@ def test_print_endpoint_label_media(tmp_path, monkeypatch):
     assert response.json() == {"status": "ok"}
     assert called, "spool_raw was not called"
     _, payload = called[0]
-    assert payload.startswith(b"N\nq799\nQ10,24\nGW20,20,100,10,")
+    assert payload.startswith(b"N\nq799\nQ1199,24\nGW20,20,100,1199,")
 
 
 def test_printer_name_from_env(monkeypatch):


### PR DESCRIPTION
## Summary
- add width/height mapping for `label100x150` media
- pad 100x150 images to the preset height and pass it to EPL generator
- allow `img_to_epl_gw` to override `Q` height
- test that EPL `Q` command uses the full 1199‑dot height

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bb3d79dcdc8332b1ba709772d19a4f