### PR TITLE
Fix continuous label form length in EPL payload

### DIFF
--- a/ditherbooth/app.py
+++ b/ditherbooth/app.py
@@ -93,7 +93,7 @@ async def print_image(
                     img,
                     y=0,
                     gap=0,
-                    label_height=25,
+                    label_height=16,
                     darkness=cfg_dark if cfg_dark is not None else None,
                     speed=cfg_speed if cfg_speed is not None else None,
                 )


### PR DESCRIPTION
## Summary
- adjust EPL header form length for continuous media so jobs don't fail
- install httpx for test suite

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bb54f128008332b86ea73e22ddeeff