### PR TITLE
Add 55x30 label media option

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Endpoints:
 * `GET /api/dev/settings`: Requires header `X-Dev-Password`. Returns full config.
 * `PUT /api/dev/settings`: Requires header `X-Dev-Password`. Accepts JSON fields:
   * `test_mode` (bool) — if true, the `/print` endpoint will process the image but skip spooling to the printer and return `{status:"ok", mode:"test"}`.
-  * `default_media` (string: one of `continuous58`, `continuous80`, `label100x150`)
+  * `default_media` (string: one of `continuous58`, `continuous80`, `label100x150`, `label55x30`)
   * `default_lang` (string: `EPL` or `ZPL`)
   * `lock_controls` (bool) — hides media/language selectors in the UI for kiosk usage.
   * `printer_name` (string, optional) — override the printer queue name used by the backend (otherwise falls back to `DITHERBOOTH_PRINTER` env, then `Zebra_LP2844`).
@@ -150,6 +150,7 @@ Available media widths (dots):
 * `continuous58` → 463
 * `continuous80` → 640 (default)
 * `label100x150` → 800
+* `label55x30` → 440
 
 You can change the default in the Dev Settings modal, or via the API.
 

--- a/ditherbooth/app.py
+++ b/ditherbooth/app.py
@@ -25,6 +25,7 @@ class Media(str, Enum):
     continuous58 = "continuous58"
     continuous80 = "continuous80"
     label100x150 = "label100x150"
+    label55x30 = "label55x30"
 
 
 class Lang(str, Enum):
@@ -37,6 +38,7 @@ MEDIA_DIMENSIONS = {
     Media.continuous80: (640, None),
     # LP2844 at 203dpi: 100mm≈800 dots, 150mm≈1200 dots
     Media.label100x150: (800, 1200),
+    Media.label55x30: (440, 240),
 }
 
 # Default to the typical CUPS queue name for Zebra LP2844 printers,

--- a/ditherbooth/static/app.js
+++ b/ditherbooth/static/app.js
@@ -264,7 +264,7 @@
     const cs = getComputedStyle(frame);
     const paddingX = parseFloat(cs.paddingLeft || '0') + parseFloat(cs.paddingRight || '0');
     let widthPx = Math.max(200, (frame.clientWidth || 320) - paddingX);
-    if (media === 'label100x150') {
+    if (media.startsWith('label')) {
       frame.classList.add('label');
       frame.classList.remove('roll');
     } else {

--- a/ditherbooth/static/index.html
+++ b/ditherbooth/static/index.html
@@ -42,6 +42,7 @@
                         <option value="continuous58">58mm continuous</option>
                         <option value="continuous80">80mm continuous</option>
                         <option value="label100x150">100x150 label</option>
+                        <option value="label55x30">55x30 label</option>
                     </select>
                 </label>
                 <label>
@@ -95,6 +96,7 @@
                                 <option value="continuous58">58mm continuous</option>
                                 <option value="continuous80">80mm continuous</option>
                                 <option value="label100x150">100x150 label</option>
+                                <option value="label55x30">55x30 label</option>
                             </select>
                         </label>
                     </div>

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -31,11 +31,13 @@ def test_preview_returns_png(monkeypatch):
     assert len(res.content) > 0
 
 
-def test_public_config_has_continuous80():
+def test_public_config_has_continuous80_and_label55x30():
     import ditherbooth.app as app_module
 
     client = TestClient(app_module.app)
     res = client.get("/api/public-config")
     assert res.status_code == 200
     data = res.json()
-    assert "continuous80" in data.get("media_options", [])
+    opts = data.get("media_options", [])
+    assert "continuous80" in opts
+    assert "label55x30" in opts


### PR DESCRIPTION
## Summary
- support new 55x30 label media
- update UI and documentation for new media option
- broaden tests to cover additional label format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68bb58988e0c83328927980d9201462a