### PR TITLE
Add label design mode checkbox

### DIFF
--- a/ditherbooth/static/index.html
+++ b/ditherbooth/static/index.html
@@ -92,6 +92,9 @@
                         <label><input type="checkbox" id="lockControls"> Lock user controls</label>
                     </div>
                     <div class="field">
+                        <label><input type="checkbox" id="designMode"> Enable label design mode</label>
+                    </div>
+                    <div class="field">
                         <label>Default media
                             <select id="defMedia">
                                 <option value="continuous58">58mm continuous</option>


### PR DESCRIPTION
## Summary
- add "Enable label design mode" option to developer settings
- confirm media selections already support 55x30 labels

## Testing
- `pip install httpx`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68bb6383ae1483329e2cb639d9fc1800