### PR TITLE
Guard localStorage access for blocked storage environments

### DIFF
--- a/ditherbooth/static/designer-v2.js
+++ b/ditherbooth/static/designer-v2.js
@@ -75,10 +75,12 @@
     if (config && config.default_media) {
       sel.value = config.default_media;
     }
-    const saved = localStorage.getItem('ditherbooth_designer_media');
-    if (saved && sel.querySelector(`option[value="${saved}"]`)) {
-      sel.value = saved;
-    }
+    try {
+      const saved = localStorage.getItem('ditherbooth_designer_media');
+      if (saved && sel.querySelector(`option[value="${saved}"]`)) {
+        sel.value = saved;
+      }
+    } catch (_) { /* localStorage unavailable */ }
   }
 
   function isTouchDevice() {
@@ -855,7 +857,7 @@
 
     $('#dFontSize').addEventListener('change', applyFontSize);
     $('#dMedia').addEventListener('change', () => {
-      localStorage.setItem('ditherbooth_designer_media', $('#dMedia').value);
+      try { localStorage.setItem('ditherbooth_designer_media', $('#dMedia').value); } catch (_) {}
       resizeCanvasToMedia();
       drawGrid();
     });


### PR DESCRIPTION
## Summary
- Wrap `localStorage` calls in try/catch to prevent crashes in Safari private mode and other environments where storage is blocked

Follow-up to #30.

## Test plan
- [ ] Designer still remembers media preset across reloads in normal browsing
- [ ] Designer doesn't crash in Safari private mode or with storage disabled